### PR TITLE
Update README.md

### DIFF
--- a/1-general-automation-api-usage-examples/define-a-cyclic-job-train/README.md
+++ b/1-general-automation-api-usage-examples/define-a-cyclic-job-train/README.md
@@ -9,7 +9,7 @@ The files arrive at random intervals. They are large csv files accompanied by a 
 
 The jobs are implemented as 3 cyclic jobs that run one after the other. The first is a FileWatcher type job that monitors the incoming directory for trigger files matching the pattern "*.done".  When a file is found, the filename is passed to the 2nd job which moves the csv file to a staging area and deletes the trigger file. Next the 3rd job is triggered which runs a python script to process that file. When this is done, the 1st FileWatcher becomes active again, and so on.
 
-![CyclicJobTrain](/images/CyclicJobTrain.png)
+![CyclicJobTrain](./images/CyclicJobTrain.png)
 
 ## Code
 


### PR DESCRIPTION
Corrected image link in cyclic-job-example-readme-fix/1-general-automation-api-usage-examples/define-a-cyclic-job-train/README.md