### PR TITLE
Add: Snowflake driver and connection profile json

### DIFF
--- a/3-infrastructure-as-code-examples/kubernetes-agent-application-pods/Snowflake/Snowflake_CCP.json
+++ b/3-infrastructure-as-code-examples/kubernetes-agent-application-pods/Snowflake/Snowflake_CCP.json
@@ -1,0 +1,21 @@
+{
+    "SNOWFLAKE_BMC": {
+      "Type": "Driver:Jdbc:Database",
+      "TargetAgent":"agent.bmc.com",
+      "StringTemplate":"jdbc:snowflake://<HOST>:<PORT>/?db=<DATABASE>",
+      "DriverJarsFolder":"/opt/agentuser/custom/jdbc",
+      "ClassName":"net.snowflake.client.jdbc.SnowflakeDriver",
+      "LineComment" : "--",
+      "StatementSeparator" : ";"
+   },
+    "SNOWF_JDBC_BMC": {
+      "Type": "ConnectionProfile:Database:JDBC",
+      "User":"CTMDEMO",
+      "Centralized": true,
+      "Host": "bmc.snowflakecomputing.com",
+      "Driver":"SNOWFLAKE_BMC",
+      "Port":"443",
+      "Password": "xyxyxyxy",
+      "DatabaseName":"TEST_DB"
+    }
+  }


### PR DESCRIPTION
it is needed mostly for documentation purposes, as a proper connection string that uses the CCP information is not in the manual.