### PR TITLE
Fix for the alerts-to-bhom BHOM event policy

### DIFF
--- a/helix-control-m/2-external-monitoring-tools-examples/alerts-to-bhom/bhom_ctm_event_policy.json
+++ b/helix-control-m/2-external-monitoring-tools-examples/alerts-to-bhom/bhom_ctm_event_policy.json
@@ -1,1 +1,430 @@
-﻿[{"name":"Update Control-M Events","types":["ADVANCED_ENRICHMENT"],"description":"Policy to update existing Control-M events","executionOrder":9999,"selectorCriteriaList":["class equals 'ControlMAlert' AND eventType equals 'U'"],"enabled":false,"configurations":[{"type":"ADVANCED_ENRICHMENT","configOrder":1,"definition":{"children":[{"all":true,"children":[{"children":[{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.eventType"}],"label":"Update eventType","id":null,"type":"enrich","value":null,"key":"$OLD.eventType"},{"children":[],"label":"Update severity","id":null,"type":"enrich","value":"$NEW.severity","key":"$OLD.severity"},{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.alertStatus"}],"label":"Update alertStatus","id":null,"type":"enrich","value":null,"key":"$OLD.alertStatus"},{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.ctmUser"}],"label":"Update ctmUser","id":null,"type":"enrich","value":null,"key":"$OLD.ctmUser"},{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.updateTime"}],"label":"Update updateTime","id":null,"type":"enrich","value":null,"key":"$OLD.updateTime"},{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.closedByControlM"}],"label":"Update closedByControlM","id":null,"type":"enrich","value":null,"key":"$OLD.closedByControlM"},{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.ticketNumber"}],"label":"Update ticketNumber","id":null,"type":"enrich","value":null,"key":"$OLD.ticketNumber"},{"children":[{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.alertNotes"}],"label":"Update alertNotes","id":null,"type":"enrich","value":null,"key":"$OLD.alertNotes"},{"children":[{"showDescription":false,"children":[],"valueType":null,"placeholderText":null,"label":null,"id":null,"type":"data","value":"$NEW.alertNotes"}],"label":"Save alertNotes","id":null,"type":"assignVar","value":null,"key":"$ctm_alert_notes"},{"children":[{"children":null,"label":null,"id":null,"type":"objectData","value":{"note":"$ctm_alert_notes","on":"OLD"}}],"name":"AddNote","label":"Add Note","id":null,"type":"function"}],"label":"alertNotes have changed","id":null,"type":"if","conditions":[{"slotName":"$OLD.alertNotes","slotOperator":"not_equals","conditionOperator":"","conditionBracket":"","conditionOrder":0,"endBracket":"","slotValue":"$NEW.alertNotes"}]},{"children":[],"label":"","id":null,"type":"else"},{"children":[{"children":[],"label":"Event = Open","id":null,"type":"enrich","value":"OPEN","key":"$OLD.status"}],"label":"alertStatus = Not_Noticed","id":null,"type":"if","conditions":[{"slotName":"$NEW.alertStatus","slotOperator":"equals","conditionOperator":"","conditionBracket":"","conditionOrder":0,"endBracket":"","slotValue":"0"},{"slotName":"$NEW.alertStatus","slotOperator":"equals","conditionOperator":"OR","conditionBracket":"","conditionOrder":1,"endBracket":"","slotValue":"Not_Noticed"}]},{"children":[],"label":"","id":null,"type":"else"},{"children":[{"children":[],"label":"Event = Acknowledged","id":null,"type":"enrich","value":"ACK","key":"$OLD.status"}],"label":"alertStatus = Noticed","id":null,"type":"if","conditions":[{"slotName":"$NEW.alertStatus","slotOperator":"equals","conditionOperator":"","conditionBracket":"","conditionOrder":0,"endBracket":"","slotValue":"1"},{"slotName":"$NEW.alertStatus","slotOperator":"equals","conditionOperator":"OR","conditionBracket":"","conditionOrder":1,"endBracket":"","slotValue":"Noticed"}]},{"children":[],"label":"","id":null,"type":"else"},{"children":[{"children":[],"label":"Event = Closed","id":null,"type":"enrich","value":"CLOSED","key":"$OLD.status"}],"label":"alertStatus = Handled","id":null,"type":"if","conditions":[{"slotName":"$NEW.alertStatus","slotOperator":"equals","conditionOperator":"","conditionBracket":"","conditionOrder":0,"endBracket":"","slotValue":"2"},{"slotName":"$NEW.alertStatus","slotOperator":"equals","conditionOperator":"OR","conditionBracket":"","conditionOrder":1,"endBracket":"","slotValue":"Handled"}]},{"children":[],"label":"","id":null,"type":"else"}],"label":"","id":null,"type":"updateOld"},{"children":[{"children":[],"name":"DropNewEvent","label":"Delete New Event","id":null,"type":"function"}],"label":"","id":null,"type":"updateNew"}],"withinInSeconds":0,"label":"Look for events with same \"alertId\" and \"Source Identifier\"","id":null,"duplicate":false,"type":"lookup","conditions":[{"slotName":"$OLD.status","slotOperator":"not_equals","conditionOperator":"","conditionBracket":"","conditionOrder":0,"endBracket":"","slotValue":"BLACKOUT"},{"slotName":"$OLD.status","slotOperator":"not_equals","conditionOperator":"AND","conditionBracket":"","conditionOrder":1,"endBracket":"","slotValue":"CLOSED"},{"slotName":"$OLD.alertId","slotOperator":"equals","conditionOperator":"AND","conditionBracket":"","conditionOrder":2,"endBracket":"","slotValue":"$NEW.alertId"},{"slotName":"$OLD.source_identifier","slotOperator":"equals","conditionOperator":"AND","conditionBracket":"","conditionOrder":3,"endBracket":"","slotValue":"$NEW.source_identifier"}],"fetchEventForClass":"ControlMAlert"}],"id":null,"label":"Policy to update existing Control-M events","type":"root"},"timeframeStatus":"","subType":""}],"timeframes":["-1"]}]
+﻿{
+    "policyList": [
+    {
+        "name": "Update Control-M Events",
+        "types": [
+            "ADVANCED_ENRICHMENT"
+        ],
+        "description": "Policy to update existing Control-M events",
+        "executionOrder": 9999,
+        "selectorCriteriaList": [
+            "class equals 'ControlMAlert' AND eventType equals 'U'"
+        ],
+        "enabled": false,
+        "configurations": [
+            {
+                "type": "ADVANCED_ENRICHMENT",
+                "configOrder": 1,
+                "definition": {
+                    "children": [
+                        {
+                            "all": true,
+                            "children": [
+                                {
+                                    "children": [
+                                        {
+                                            "children": [
+                                                {
+                                                    "showDescription": false,
+                                                    "children": [],
+                                                    "valueType": null,
+                                                    "placeholderText": null,
+                                                    "label": null,
+                                                    "id": null,
+                                                    "type": "data",
+                                                    "value": "$NEW.eventType"
+                                                }
+                                            ],
+                                            "label": "Update eventType",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": null,
+                                            "key": "$OLD.eventType"
+                                        },
+                                        {
+                                            "children": [],
+                                            "label": "Update severity",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": "$NEW.severity",
+                                            "key": "$OLD.severity"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "showDescription": false,
+                                                    "children": [],
+                                                    "valueType": null,
+                                                    "placeholderText": null,
+                                                    "label": null,
+                                                    "id": null,
+                                                    "type": "data",
+                                                    "value": "$NEW.alertStatus"
+                                                }
+                                            ],
+                                            "label": "Update alertStatus",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": null,
+                                            "key": "$OLD.alertStatus"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "showDescription": false,
+                                                    "children": [],
+                                                    "valueType": null,
+                                                    "placeholderText": null,
+                                                    "label": null,
+                                                    "id": null,
+                                                    "type": "data",
+                                                    "value": "$NEW.ctmUser"
+                                                }
+                                            ],
+                                            "label": "Update ctmUser",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": null,
+                                            "key": "$OLD.ctmUser"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "showDescription": false,
+                                                    "children": [],
+                                                    "valueType": null,
+                                                    "placeholderText": null,
+                                                    "label": null,
+                                                    "id": null,
+                                                    "type": "data",
+                                                    "value": "$NEW.updateTime"
+                                                }
+                                            ],
+                                            "label": "Update updateTime",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": null,
+                                            "key": "$OLD.updateTime"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "showDescription": false,
+                                                    "children": [],
+                                                    "valueType": null,
+                                                    "placeholderText": null,
+                                                    "label": null,
+                                                    "id": null,
+                                                    "type": "data",
+                                                    "value": "$NEW.closedByControlM"
+                                                }
+                                            ],
+                                            "label": "Update closedByControlM",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": null,
+                                            "key": "$OLD.closedByControlM"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "showDescription": false,
+                                                    "children": [],
+                                                    "valueType": null,
+                                                    "placeholderText": null,
+                                                    "label": null,
+                                                    "id": null,
+                                                    "type": "data",
+                                                    "value": "$NEW.ticketNumber"
+                                                }
+                                            ],
+                                            "label": "Update ticketNumber",
+                                            "id": null,
+                                            "type": "enrich",
+                                            "value": null,
+                                            "key": "$OLD.ticketNumber"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "children": [
+                                                        {
+                                                            "showDescription": false,
+                                                            "children": [],
+                                                            "valueType": null,
+                                                            "placeholderText": null,
+                                                            "label": null,
+                                                            "id": null,
+                                                            "type": "data",
+                                                            "value": "$NEW.alertNotes"
+                                                        }
+                                                    ],
+                                                    "label": "Update alertNotes",
+                                                    "id": null,
+                                                    "type": "enrich",
+                                                    "value": null,
+                                                    "key": "$OLD.alertNotes"
+                                                },
+                                                {
+                                                    "children": [
+                                                        {
+                                                            "showDescription": false,
+                                                            "children": [],
+                                                            "valueType": null,
+                                                            "placeholderText": null,
+                                                            "label": null,
+                                                            "id": null,
+                                                            "type": "data",
+                                                            "value": "$NEW.alertNotes"
+                                                        }
+                                                    ],
+                                                    "label": "Save alertNotes",
+                                                    "id": null,
+                                                    "type": "assignVar",
+                                                    "value": null,
+                                                    "key": "$ctm_alert_notes"
+                                                },
+                                                {
+                                                    "children": [
+                                                        {
+                                                            "children": null,
+                                                            "label": null,
+                                                            "id": null,
+                                                            "type": "objectData",
+                                                            "value": {
+                                                                "note": "$ctm_alert_notes",
+                                                                "on": "OLD"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "name": "AddNote",
+                                                    "label": "Add Note",
+                                                    "id": null,
+                                                    "type": "function"
+                                                }
+                                            ],
+                                            "label": "alertNotes have changed",
+                                            "id": null,
+                                            "type": "if",
+                                            "conditions": [
+                                                {
+                                                    "slotName": "$OLD.alertNotes",
+                                                    "slotOperator": "not_equals",
+                                                    "conditionOperator": "",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 0,
+                                                    "endBracket": "",
+                                                    "slotValue": "$NEW.alertNotes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "children": [],
+                                            "label": "",
+                                            "id": null,
+                                            "type": "else"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "children": [],
+                                                    "label": "Event = Open",
+                                                    "id": null,
+                                                    "type": "enrich",
+                                                    "value": "OPEN",
+                                                    "key": "$OLD.status"
+                                                }
+                                            ],
+                                            "label": "alertStatus = Not_Noticed",
+                                            "id": null,
+                                            "type": "if",
+                                            "conditions": [
+                                                {
+                                                    "slotName": "$NEW.alertStatus",
+                                                    "slotOperator": "equals",
+                                                    "conditionOperator": "",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 0,
+                                                    "endBracket": "",
+                                                    "slotValue": "0"
+                                                },
+                                                {
+                                                    "slotName": "$NEW.alertStatus",
+                                                    "slotOperator": "equals",
+                                                    "conditionOperator": "OR",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 1,
+                                                    "endBracket": "",
+                                                    "slotValue": "Not_Noticed"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "children": [],
+                                            "label": "",
+                                            "id": null,
+                                            "type": "else"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "children": [],
+                                                    "label": "Event = Acknowledged",
+                                                    "id": null,
+                                                    "type": "enrich",
+                                                    "value": "ACK",
+                                                    "key": "$OLD.status"
+                                                }
+                                            ],
+                                            "label": "alertStatus = Noticed",
+                                            "id": null,
+                                            "type": "if",
+                                            "conditions": [
+                                                {
+                                                    "slotName": "$NEW.alertStatus",
+                                                    "slotOperator": "equals",
+                                                    "conditionOperator": "",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 0,
+                                                    "endBracket": "",
+                                                    "slotValue": "1"
+                                                },
+                                                {
+                                                    "slotName": "$NEW.alertStatus",
+                                                    "slotOperator": "equals",
+                                                    "conditionOperator": "OR",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 1,
+                                                    "endBracket": "",
+                                                    "slotValue": "Noticed"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "children": [],
+                                            "label": "",
+                                            "id": null,
+                                            "type": "else"
+                                        },
+                                        {
+                                            "children": [
+                                                {
+                                                    "children": [],
+                                                    "label": "Event = Closed",
+                                                    "id": null,
+                                                    "type": "enrich",
+                                                    "value": "CLOSED",
+                                                    "key": "$OLD.status"
+                                                }
+                                            ],
+                                            "label": "alertStatus = Handled",
+                                            "id": null,
+                                            "type": "if",
+                                            "conditions": [
+                                                {
+                                                    "slotName": "$NEW.alertStatus",
+                                                    "slotOperator": "equals",
+                                                    "conditionOperator": "",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 0,
+                                                    "endBracket": "",
+                                                    "slotValue": "2"
+                                                },
+                                                {
+                                                    "slotName": "$NEW.alertStatus",
+                                                    "slotOperator": "equals",
+                                                    "conditionOperator": "OR",
+                                                    "conditionBracket": "",
+                                                    "conditionOrder": 1,
+                                                    "endBracket": "",
+                                                    "slotValue": "Handled"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "children": [],
+                                            "label": "",
+                                            "id": null,
+                                            "type": "else"
+                                        }
+                                    ],
+                                    "label": "",
+                                    "id": null,
+                                    "type": "updateOld"
+                                },
+                                {
+                                    "children": [
+                                        {
+                                            "children": [],
+                                            "name": "DropNewEvent",
+                                            "label": "Delete New Event",
+                                            "id": null,
+                                            "type": "function"
+                                        }
+                                    ],
+                                    "label": "",
+                                    "id": null,
+                                    "type": "updateNew"
+                                }
+                            ],
+                            "withinInSeconds": 0,
+                            "label": "Look for events with same \"alertId\" and \"Source Identifier\"",
+                            "id": null,
+                            "duplicate": false,
+                            "type": "lookup",
+                            "conditions": [
+                                {
+                                    "slotName": "$OLD.status",
+                                    "slotOperator": "not_equals",
+                                    "conditionOperator": "",
+                                    "conditionBracket": "",
+                                    "conditionOrder": 0,
+                                    "endBracket": "",
+                                    "slotValue": "BLACKOUT"
+                                },
+                                {
+                                    "slotName": "$OLD.status",
+                                    "slotOperator": "not_equals",
+                                    "conditionOperator": "AND",
+                                    "conditionBracket": "",
+                                    "conditionOrder": 1,
+                                    "endBracket": "",
+                                    "slotValue": "CLOSED"
+                                },
+                                {
+                                    "slotName": "$OLD.alertId",
+                                    "slotOperator": "equals",
+                                    "conditionOperator": "AND",
+                                    "conditionBracket": "",
+                                    "conditionOrder": 2,
+                                    "endBracket": "",
+                                    "slotValue": "$NEW.alertId"
+                                },
+                                {
+                                    "slotName": "$OLD.source_identifier",
+                                    "slotOperator": "equals",
+                                    "conditionOperator": "AND",
+                                    "conditionBracket": "",
+                                    "conditionOrder": 3,
+                                    "endBracket": "",
+                                    "slotValue": "$NEW.source_identifier"
+                                }
+                            ],
+                            "fetchEventForClass": "ControlMAlert"
+                        }
+                    ],
+                    "id": null,
+                    "label": "Policy to update existing Control-M events",
+                    "type": "root"
+                },
+                "timeframeStatus": "",
+                "subType": ""
+            }
+        ],
+        "timeframes": [
+            "-1"
+        ]
+    }
+],
+    "dataTablesMap": []
+}


### PR DESCRIPTION
Updated the file to latest policy export/import format, otherwise users are unable to import it into BHOM.
Also "pretty-printed" the JSON file for easier reading